### PR TITLE
NEW: Update npm if instructed via nodejs_update_npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Tested on Ubuntu 12.04 Server.
 The default variables are as follows:
 
     nodejs_do_bower_install: false
+    nodejs_update_npm: false
     nodejs_global_packages: []
     nodejs_user: '{{ ansible_ssh_user }}'
 
@@ -19,6 +20,7 @@ The default variables are as follows:
     - hosts: 'servers'
       roles:
         - role: 'ssilab.nodejs'
+          nodejs_update_npm: true               # If true, install the latest npm immediately after installing Node.js
           nodejs_user: 'hercules'
           nodejs_global_packages:
           	- 'bower'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,5 @@
 ---
 nodejs_do_bower_install: false
+nodejs_update_npm: false
 nodejs_global_packages: []
 nodejs_user: '{{ ansible_ssh_user }}'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -21,6 +21,18 @@
   sudo: 'yes'
   apt: pkg=nodejs
 
+- name: 'Update npm'
+  tags:
+    - 'nodejs'
+    - 'npm'
+  sudo: 'yes'
+  npm: >
+    name=npm
+    state=latest
+    global=yes
+    registry=https://registry.npmjs.org
+  when: 'nodejs_update_npm | bool'
+
 - name: 'Install npm global packages'
   tags:
     - 'nodejs'


### PR DESCRIPTION
PPA npm is 1.4.28, latest is ~2.1. Apparently a bunch of races were fixed, so hopefully this will help solve some npm issues. Updating is off by default to avoid breaking anything.