### PR TITLE
FIX: Update cache before installing npm

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,7 +19,9 @@
 - name: 'Install Node.js'
   tags: 'nodejs'
   sudo: 'yes'
-  apt: pkg=nodejs
+  apt: >
+    pkg=nodejs
+    update_cache=true
 
 - name: 'Update npm'
   tags:


### PR DESCRIPTION
Required to ensure we grab the latest npm from the PPA. Had trouble on Travis without this.